### PR TITLE
Added title formatting for the link template

### DIFF
--- a/FFHelperRepository.py
+++ b/FFHelperRepository.py
@@ -36,7 +36,7 @@ class Repository:
         return comment
 
 class StringConstants:
-    LINK_TEMPLATE = """[Here is link number {} - Previous text "{}"]({})
+    LINK_TEMPLATE = """#[Here is link number {} - Previous text "{}"]({})
 
 """
 


### PR DESCRIPTION
I added a `#` character to the start of the link template, which should
cause reddit's markdown formatting to format the links as a title,
causing them to be bigger and even easier to click on when on mobile.

Yes. A *singular character* difference. lol